### PR TITLE
ci: add multi-arch GitHub Actions workflow for GeoServer image

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,47 @@
+name: Build and Push GeoServer Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    name: Build and Push Multi-Arch Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      GEOSERVER_VERSION: 2.27.2
+      IMAGE_VERSION: 9.0.106-jdk11-temurin-jammy
+      DEFAULT_OFFICIAL_PLUGINS: "gdal,monitor,vectortiles,mbstyle"
+      DEFAULT_COMMUNITY_PLUGINS: "jdbcconfig,jdbcstore,sec-oauth2-openid-connect"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image (multi-arch)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/tosca-geoserver:2.27.2
+          build-args: |
+            GEOSERVER_VERSION=${{ env.GEOSERVER_VERSION }}
+            IMAGE_VERSION=${{ env.IMAGE_VERSION }}
+            DEFAULT_OFFICIAL_PLUGINS=${{ env.DEFAULT_OFFICIAL_PLUGINS }}
+            DEFAULT_COMMUNITY_PLUGINS=${{ env.DEFAULT_COMMUNITY_PLUGINS }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
+      platforms:
+        - linux/arm64
+        # - linux/amd64 # Intel/AMD (CI, servers) – enable for x86_64 builds
       args:
         GEOSERVER_VERSION: ${GEOSERVER_VERSION}
     image: dcs-geoserver:${GEOSERVER_VERSION}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,20 +3,27 @@
 # -----------------------------
 ARG IMAGE_VERSION=9.0.106-jdk11-temurin-jammy
 FROM tomcat:${IMAGE_VERSION}
-
 LABEL maintainer="orttak"
 
 # -----------------------------
-# Build-time args
+# Build-time args (IMAGE IDENTITY)
 # -----------------------------
 ARG GEOSERVER_VERSION=2.27.2
 ARG JAVA_OPTS="-Xms512m -Xmx1024m"
+# Build-time defaults
+ARG DEFAULT_OFFICIAL_PLUGINS="gdal,monitor,vectortiles,mbstyle"
+ARG DEFAULT_COMMUNITY_PLUGINS="jdbcconfig,jdbcstore,sec-oauth2-openid-connect"
 
 # -----------------------------
-# Runtime ENV
+# Runtime ENV (OVERRIDABLE IN DEV)
 # -----------------------------
 ENV GEOSERVER_VERSION=${GEOSERVER_VERSION}
 ENV GEOSERVER_DATA_DIR="/geoserver_data/data"
+
+# Runtime defaults (image içinden gelir)
+ENV OFFICIAL_PLUGINS=${DEFAULT_OFFICIAL_PLUGINS}
+ENV COMMUNITY_PLUGINS=${DEFAULT_COMMUNITY_PLUGINS}
+
 
 ENV GEOSERVER_CORS_ENABLED=true
 ENV GEOSERVER_CORS_ALLOWED_ORIGINS=*
@@ -31,26 +38,30 @@ ENV JAVA_OPTS=${JAVA_OPTS}
 RUN apt-get update && apt-get install -y \
     curl wget unzip procps \
     python3 python3-pip \
-    && apt-get install -y gettext-base \
-    && rm -rf /var/lib/apt/lists/* 
+    gettext-base \
+    && rm -rf /var/lib/apt/lists/*
+
 # -----------------------------
-# Download & install GeoServer
+# Download & install GeoServer (BUILD-TIME, FIXED)
 # -----------------------------
 RUN cd /usr/local/tomcat/webapps && \
-    wget -q https://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-war.zip \
-      -O geoserver.zip && \
+    curl -fL https://downloads.sourceforge.net/project/geoserver/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-war.zip \
+      -o geoserver.zip && \
     unzip -q geoserver.zip && \
     unzip -q geoserver.war -d geoserver && \
     rm -f geoserver.zip geoserver.war && \
     mkdir -p ${GEOSERVER_DATA_DIR}
 
+# Store image GeoServer version for runtime mismatch warning
+RUN mkdir -p /opt/geoserver && \
+    echo "${GEOSERVER_VERSION}" > /opt/geoserver/.image_version
 # -----------------------------
-# Plugin manager (Python stays)
+# Plugin manager (runtime use)
 # -----------------------------
 COPY plugin_manager /opt/geoserver/plugin_manager
 
 # -----------------------------
-# Security + entrypoint scripts (XML-based password init)
+# Entrypoint & helper scripts
 # -----------------------------
 COPY scripts /scripts
 RUN chmod +x /scripts/*.sh
@@ -59,11 +70,8 @@ RUN chmod +x /scripts/*.sh
 # Volumes
 # -----------------------------
 VOLUME ${GEOSERVER_DATA_DIR}
-RUN python3 /opt/geoserver/plugin_manager/cli.py \
-  --version ${GEOSERVER_VERSION} \
-  --community "${COMMUNITY_PLUGINS}" \
-  --official "${OFFICIAL_PLUGINS}"
+
 # -----------------------------
-# Start (entrypoint handles password init + then Tomcat)
+# Start (runtime logic in entrypoint)
 # -----------------------------
 ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -59,6 +59,25 @@ if [ -n "${PROXY_BASE_URL:-}" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Runtime plugin installation (from .env)
+# -------------------------------------------------------------------
+
+PLUGIN_STATE_FILE="${GEOSERVER_DATA_DIR}/.plugins_state"
+PLUGIN_STATE="$(echo "${GEOSERVER_VERSION}|${OFFICIAL_PLUGINS:-}|${COMMUNITY_PLUGINS:-}" | sha256sum | awk '{print $1}')"
+if [ ! -f "$PLUGIN_STATE_FILE" ] || [ "$(cat $PLUGIN_STATE_FILE)" != "$PLUGIN_STATE" ]; then
+  echo "🧩 Plugin configuration changed, installing plugins..."
+  python3 /opt/geoserver/plugin_manager/cli.py \
+    --version "${GEOSERVER_VERSION}" \
+    --official "${OFFICIAL_PLUGINS:-}" \
+    --community "${COMMUNITY_PLUGINS:-}"
+
+  echo "$PLUGIN_STATE" > "$PLUGIN_STATE_FILE"
+  echo "✅ Plugins installed / updated"
+else
+  echo "ℹ️  Plugin configuration unchanged, skipping"
+fi
+
+# -------------------------------------------------------------------
 # 5) Start Tomcat (PID 1)
 # -------------------------------------------------------------------
 echo "Starting Tomcat..."


### PR DESCRIPTION
- Build and push GeoServer Docker image via GitHub Actions
- Enable buildx for linux/amd64 and linux/arm64
- Use build-time ARGs for GeoServer version and default plugins
- Push image to GHCR without requiring runtime .env files